### PR TITLE
Updated the deprecated gemini model names with the corresponding stable models

### DIFF
--- a/utils/api.py
+++ b/utils/api.py
@@ -17,8 +17,8 @@ logging.getLogger('httpx').setLevel(logging.WARNING)
 # Read API keys from environment variables
 API_KEY = os.environ.get("GEMINI_API_KEY", "")
 READ_API_KEY = os.environ.get("JINA_API_KEY", "")
-FACT_Model = "gemini-2.5-flash-preview-05-20"
-Model = "gemini-2.5-pro-preview-06-05"
+FACT_Model = "gemini-2.5-flash"
+Model = "gemini-2.5-pro"
 
 class AIClient:
     


### PR DESCRIPTION
Hi @Ayanami0730 ,

The currently used gemini models are deprecated:

  - gemini-2.5-flash-preview-05-20
  - gemini-2.5-pro-preview-06-05

This is causing the deep research bench to fail.

Here's the release notes from Google informing the same: https://ai.google.dev/gemini-api/docs/changelog#11-04-2025

SS: 
<img width="1430" height="784" alt="Screenshot 2025-12-21 at 10 08 00 PM" src="https://github.com/user-attachments/assets/16ce1050-ea9a-4657-83fb-9af725068173" />
