### PR TITLE
Gabriel/asknews deepnews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env and fill in. .env is gitignored — never commit real keys.
+#   cp .env.example .env
+
+# --- DeepNews generation (run_deepnews.py) ---
+ASKNEWS_API_KEY=
+
+# --- Benchmark evaluation (run_benchmark.sh: RACE + FACT) ---
+# Judge backend: "openai" (direct) or "openrouter" (default upstream).
+LLM_BACKEND=openai
+# OpenAI direct: needs gpt-5.5 (RACE) + gpt-5.4-mini (FACT) access.
+OPENAI_API_KEY=
+# OpenRouter alternative (only if LLM_BACKEND=openrouter):
+# OPENROUTER_API_KEY=
+# Jina key for FACT citation scraping (free tier at jina.ai).
+JINA_API_KEY=

--- a/BENCHMARKING_DEEPNEWS.md
+++ b/BENCHMARKING_DEEPNEWS.md
@@ -1,0 +1,225 @@
+# Benchmarking DeepNews on DeepResearch Bench
+
+How to evaluate AskNews' **DeepNews** agent on **DeepResearch Bench (DRB)** and get a comparable score.
+
+---
+
+## 1. How the two pieces fit together
+
+DeepResearch Bench is **bring-your-own-output**. It does *not* call your agent. The flow is:
+
+```
+query.jsonl (100 tasks)  ──►  YOUR runner calls DeepNews  ──►  raw_data/<model>.jsonl
+                                                                      │
+                                                                      ▼
+                                                            run_benchmark.sh
+                                                          ┌───────────┴───────────┐
+                                                       RACE judge              FACT pipeline
+                                                     (GPT-5.5, report       (extract citations →
+                                                      quality vs ref)        dedup → Jina scrape →
+                                                                             validate support)
+                                                          └───────────┬───────────┘
+                                                              race_result.txt / fact_result.txt
+```
+
+Our only real work is the **runner**: take the 100 benchmark prompts, run each through DeepNews, and emit one JSONL line per task in the exact shape DRB expects. Everything after that is the upstream eval harness, unchanged.
+
+### What DRB requires of each output line
+`data/test_data/raw_data/<model_name>.jsonl`, one JSON object per line:
+```json
+{"id": 1, "prompt": "<original query text>", "article": "<full report WITH inline citations>"}
+```
+- `id` and `prompt` must match `data/prompt_data/query.jsonl` (100 tasks: 50 zh + 50 en, across 22 topics).
+- `article` is the final report. **Inline citations with real URLs are mandatory** — the FACT pipeline extracts statement→URL pairs from the article body and scrapes each URL to verify support. No URLs in the body ⇒ FACT score ≈ 0.
+
+### What the two scores measure
+- **RACE** — report quality (Comprehensiveness, Insight/Depth, Instruction-Following, Readability), judged by GPT-5.5 against a reference report, with task-adaptive weights.
+- **FACT** — Citation Accuracy (% of citations whose source actually supports the claim) and Effective Citations (avg # of verifiably-supported citations per task).
+
+---
+
+## 2. The DeepNews call
+
+DeepNews is OpenAI-compatible (`POST /v1/chat/deepnews`), exposed through the SDK as `sdk.chat.get_deep_news(...)`. The runner (§3) calls it like this:
+
+```python
+from asknews_sdk import AskNewsSDK
+
+sdk = AskNewsSDK(api_key="...", scopes=["chat", "news", "stories"])
+
+response = sdk.chat.get_deep_news(
+    messages=[{"role": "user", "content": prompt}],
+    stream=True,
+    engine="v1.5",                  # parallel tool calling + improved research
+    model="claude-sonnet-4-6",      # judged report — keep fixed across the run
+    search_depth=2,                 # min research levels
+    max_depth=6,                    # max research depth (depth↑ = quality↑, cost/time↑)
+    max_parallel_tool_calls=4,
+    sources=["asknews", "google", "wiki", "x"],
+    inline_citations="markdown_link",  # FACT-compatible citations (SDK default)
+    append_references=True,            # references section (SDK default)
+    asknews_watermark=False,           # keep the watermark out of the judged report
+    max_tokens=32000,                  # SDK default 9999 truncates deep reports
+    return_sources=True,
+)
+for msg in response:                   # stream yields content chunks AND source objects
+    choices = getattr(msg, "choices", None)   # source objects have no .choices
+    if choices and choices[0].delta.content:
+        print(choices[0].delta.content, end="", flush=True)
+```
+
+**Citations — already handled, no engineering needed.** DeepNews emits inline citations as markdown links wrapped in brackets, e.g. `...20% of the world's oil [[PN](http://www.theportugalnews.com/...)][[TI](https://timesofindia.../...)]`. DRB's FACT extractor (`utils/extract.py`) *natively* parses this: its accepted citation form #4 is exactly `[Citation Source](Citation Link)`, matched by the regex `\[([^\]]+)\]\(([^)]+)\)` (the outer bracket of `[[PN](url)]` is harmless; the inner `[PN](url)` is what matches; `ref_idx` is set to `0` for this form). So the URLs DeepNews already produces flow straight into FACT verification — **no prompt-wrapping or reference reconciliation required.**
+
+**The actual preprocessing requirement — extract the report from the stream.** A real DeepNews response is not pure report text. It contains:
+1. **Agent preamble / reasoning chatter** before the report — e.g. *"I now have sufficient information to provide a comprehensive answer. Let me compile everything."*
+2. The report itself wrapped in **`<final_answer> ... </final_answer>`** tags.
+3. Sometimes a repeat of (1) between multiple `<final_answer>` blocks if the agent iterates.
+
+The `article` field must contain **only the final report body** — strip the preamble and the `<final_answer>` tags. If chatter leaks in: FACT extraction wastes calls on URL-free narration (minor), but RACE's Readability/Instruction-Following scores suffer (the judge sees meta-commentary that isn't part of the report). Extraction logic:
+- Capture the content of the **last** `<final_answer>...</final_answer>` block (the agent's final compiled answer). Regex: `re.findall(r"<final_answer>(.*?)</final_answer>", full, re.DOTALL)` → take `[-1]`.
+- Fallback if no tags are present: strip leading lines until the first markdown heading (`#`) and use the remainder.
+- Keep the markdown citations exactly as-is — do not rewrite the `[[label](url)]` markers.
+
+Validate this on the 2-task dry run (§4): open the output and confirm `article` starts at the report's first heading, contains the `[[label](url)]` citations, and has no `<final_answer>` tags or "I now have sufficient information" preamble.
+
+---
+
+## 3. The runner (`run_deepnews.py`)
+
+Implemented at the repo root (`run_deepnews.py`). It loads the queries, runs each through `get_deep_news`, extracts the report body, and writes DRB-shaped lines to `data/test_data/raw_data/<model-tag>.jsonl`.
+
+### Usage
+```bash
+# how many tasks to run:
+python run_deepnews.py --limit 2          # first 2 tasks (smoke test)
+python run_deepnews.py --limit 10 --only-en   # first 10 English-only tasks
+python run_deepnews.py --ids 1,5,42        # specific task ids
+python run_deepnews.py                      # all 100
+
+# DeepNews config (all optional, sensible defaults shown):
+python run_deepnews.py \
+  --model claude-sonnet-4-6 --engine v1.5 \
+  --search-depth 2 --max-depth 6 --max-parallel-tool-calls 4 \
+  --sources asknews,google,wiki,x \
+  --max-tokens 32000 --workers 4 --retries 3
+```
+`ASKNEWS_API_KEY` is read from the env (falls back to the key in `main.py` if unset).
+
+### Flags
+| Flag | Purpose |
+|---|---|
+| `-n, --limit N` | Run the first N tasks (after any language filter). Omit → all 100. |
+| `--ids 1,5,42` | Run exactly these task ids (overrides `--limit`/language filters). |
+| `--only-en` / `--only-zh` | Restrict to one language (50 each). |
+| `--model` | DeepNews model under test (the report being scored). |
+| `--engine` | `v1` / `v1.5` / `v2.0`. |
+| `--search-depth` / `--max-depth` | Research depth band. Higher = better RACE, more cost/time. |
+| `--max-tokens` | Output cap. **Default 32000** — the SDK default of 9999 truncates deep reports (the streamed reasoning counts against it too). |
+| `--workers` | Concurrent DeepNews calls. |
+| `--model-tag` | Output filename stem. Default `deepnews-<engine>-<model>-d<max_depth>`. |
+| `--force` | Re-run tasks already present in the output. |
+
+### What it does for correctness
+- **Resumable** — appends each line as it completes; on restart it skips ids already in the file. Failed tasks are *not* written, so just re-run the same command to retry them.
+- **Report extraction** — accumulates only content chunks (the stream also yields source objects, which have no `.choices`), then takes the **last** `<final_answer>…</final_answer>` block, falling back to "first markdown heading onward". Citations are left exactly as DeepNews emits them.
+- **Guards** — rejects an article shorter than `--min-chars` (500) or with no `http` citation, so truncated/empty runs fail loudly instead of silently tanking the score.
+- **DeepNews defaults set deliberately** — `inline_citations="markdown_link"` + `append_references=True` (FACT-compatible citations), `asknews_watermark=False` (keeps the watermark out of the judged report), `max_tokens=32000`.
+- **Bounded concurrency + retries** — `ThreadPoolExecutor(--workers)`, exponential backoff (`--retries`).
+- On finish it prints the exact `TARGET_MODELS=("<tag>")` line to paste into `run_benchmark.sh`.
+
+---
+
+## 4. Execution plan
+
+**Phase 0 — env.** Create a venv and install everything (runner SDK + benchmark deps):
+```bash
+python -m venv env && source env/bin/activate
+pip install -r requirements.txt        # includes asknews-sdk
+
+# Keys: copy the template and fill it in (.env is gitignored).
+cp .env.example .env
+#   ASKNEWS_API_KEY  — DeepNews generation (run_deepnews.py auto-loads .env)
+#   LLM_BACKEND=openai, OPENAI_API_KEY — gpt-5.5 (RACE) + gpt-5.4-mini (FACT)
+#   JINA_API_KEY     — FACT web scraping (required regardless of backend)
+
+# run_benchmark.sh does NOT auto-load .env — export the eval keys into the shell first:
+set -a; source .env; set +a
+```
+> Defaults `RACE_MODEL=gpt-5.5`, `FACT_MODEL=gpt-5.4-mini` kick in automatically. Don't override them to a non-default judge unless you only care about internal A/B — a different judge makes scores non-comparable to the leaderboard.
+
+**Phase 1 — dry run (2 tasks, 1 EN + 1 ZH).** Generate two reports and inspect them:
+```bash
+python run_deepnews.py --ids 1,51        # id 1 is zh, id 51 is en
+```
+Open `data/test_data/raw_data/deepnews-v1.5-claude-sonnet-4-6-d6.jsonl` and confirm: (a) `article` starts at the report's first heading — no preamble, no `<final_answer>` tags, (b) it contains inline `[label](url)` citations, (c) the zh task returns a zh report. Then validate the eval end-to-end cheaply:
+```bash
+# TARGET_MODELS in run_benchmark.sh is already set to deepnews-v1.5-claude-sonnet-4-6-d6
+# uncomment LIMIT="--limit 2" in run_benchmark.sh for the 2-task check
+bash run_benchmark.sh
+```
+Confirm `results/race/<tag>/race_result.txt` and `results/fact/<tag>/fact_result.txt` populate.
+
+**Phase 1.5 — optional cheaper first pass.** English-only (50 tasks) roughly halves both generation and evaluation cost and is a fast way to get a directional score:
+```bash
+python run_deepnews.py --only-en
+# then run_benchmark.sh with ONLY_EN="--only_en" uncommented
+```
+
+**Phase 2 — full generation.** Run the runner over all 100. Expect this to be the long pole (each task is a multi-minute agentic run; ~4 in parallel). Resume on any interruption — just re-run the same command. Sanity-check: `wc -l` on the output = 100, no truncated articles.
+```bash
+python run_deepnews.py            # resumes; skips ids already done
+```
+
+**Phase 3 — full evaluation.** Re-comment `LIMIT` (and `ONLY_EN` if set), run `bash run_benchmark.sh`. RACE scores every report vs the reference (criteria are pre-shipped — no generation calls); FACT extracts → dedups → Jina-scrapes → validates every citation. See §5 for costs.
+
+**Phase 4 — read results.** `race_result.txt` (4 sub-dimensions + overall) and `fact_result.txt` (Citation Accuracy, Effective Citations). Compare against leaderboard entries. To attribute wins/losses, slice by `topic` and `language` from `query.jsonl`.
+
+---
+
+## 5. Cost (OpenAI evaluator)
+
+**Pricing (2026):** GPT-5.5 (RACE) **$5 / $30** per 1M in/out (batch $2.50/$15); GPT-5.4-mini (FACT) **$0.75 / $4.50**.
+
+Two facts from the DRB code shape the cost: RACE criteria are **pre-shipped** (`data/criteria_data/criteria.jsonl`) so RACE = ~1 scoring call per task (target + reference scored together, occasionally chunked for long articles); FACT validation is **1 call per unique cited URL** (~25–40/task for citation-heavy DeepNews reports), which is the FACT call driver.
+
+| Phase | Judge model | ~Per task | **Full 100 tasks** |
+|---|---|---|---|
+| RACE | gpt-5.5 | ~$0.35–0.50 | **~$35–55** |
+| FACT | gpt-5.4-mini | ~$0.20–0.35 | **~$20–35** |
+| **Total OpenAI** | | | **~$55–90** (≈ **$70** typical) |
+
+- **`--only-en`** (50 tasks) ≈ halves it → ~$25–45. The Phase-1 dry run (2 tasks) is ~$1–2.
+- **Reruns / `--force`** multiply linearly.
+- Batch API for RACE would ~halve that phase, but DRB calls the judge synchronously (would require editing `utils/api.py`).
+
+**Not OpenAI costs (don't forget):**
+- **Jina** (FACT scraping) — required regardless of backend; free tier + cheap paid (a few $ for a full run).
+- **AskNews / DeepNews generation** — the 100 deep-research runs themselves, billed by AskNews (not OpenAI), and likely your **largest single cost**. Scales with `--max-depth`, `--max-parallel-tool-calls`, and source count. Check your AskNews per-request/credit rate before the full run.
+
+## 5b. Time / risk
+
+| Item | Driver | Mitigation |
+|---|---|---|
+| **Generation time** | 100 multi-step agent runs, minutes each | `--workers 4`; resume on interruption |
+| **Agent chatter / `<final_answer>` tags leak into article** | DeepNews streams reasoning + tagged report | `extract_report()` in the runner; verify in Phase 1 — **top risk for RACE** |
+| **Truncated/short articles** | Stream drops, timeouts, `max_tokens` too low | `--max-tokens 32000`, length + `http` guard, resume; never emit partials |
+| **Comparability** | Must use GPT-5.5 evaluator (current official) | Keep default `RACE_MODEL`/`FACT_MODEL`; don't swap judges |
+| **gpt-5.5 access** | Your OpenAI key must be entitled to gpt-5.5 | Verify before the full run, or use OpenRouter as fallback backend |
+| **Reproducibility (for leaderboard)** | Closed-source agent | Config encoded in `--model-tag`; document the exact `get_deep_news` flags |
+
+## 6. Decisions to lock before running
+- **Model under test** — `claude-sonnet-4-6` vs `claude-opus-4-6` vs `open-source-best`. Fix one; it defines "the DeepNews score." Optionally benchmark 2–3 as separate model tags.
+- **Depth budget** — `search_depth` / `max_depth`. Higher = better RACE, more cost. Recommend pinning `max_depth=6` and noting it.
+- **Source set** — `["asknews","google","wiki","x"]` is a reasonable default; add `reddit`/`graph` if the topic mix benefits.
+- **Report extraction** — confirm `extract_report()` matches the real stream shape in Phase 1 (§2). Citations themselves need no work — DRB parses DeepNews' `[[label](url)]` format natively.
+
+## 7. Leaderboard submission (optional)
+Per DRB README, to get an official entry email the maintainers with: the raw `<model>.jsonl`, a temporary GPT-5.5 key for verification, a reproducibility/product link, model metadata, and (recommended) the `race_result.txt` / `fact_result.txt`.
+
+---
+
+### TL;DR
+1. `python run_deepnews.py --ids 1,51` — dry run; eyeball the two reports.
+2. `python run_deepnews.py` — generate all 100 (resumable; use `--limit`/`--only-en`/`--ids` to scope).
+3. Set `TARGET_MODELS=("<tag>")`, export `LLM_BACKEND=openai` + `OPENAI_API_KEY` (gpt-5.5 access) + `JINA_API_KEY`, then `bash run_benchmark.sh`.
+4. Read RACE + FACT; slice by topic/language. Budget **~$70 of OpenAI** for a full eval (plus Jina + AskNews generation). Citations are already DRB-compatible — the make-or-break detail is **cleanly extracting the report body** from the agent stream, which the runner handles.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Providing these files can help us speed up verification, but the raw generated r
 ### Prerequisites
 
 - Python 3.9+
+- **AskNews API key** — to generate DeepNews outputs (see [Generate outputs with AskNews DeepNews](#-generate-outputs-with-asknews-deepnews-this-fork))
 - OpenRouter or OpenAI API key (for LLM evaluation)
 - Jina API key (for web scraping in FACT evaluation)
 
@@ -167,7 +168,9 @@ Providing these files can help us speed up verification, but the raw generated r
 ```bash
 git clone https://github.com/your-username/deep_research_bench.git
 cd deep_research_bench
-pip install -r requirements.txt
+python -m venv env && source env/bin/activate
+pip install -r requirements.txt          # includes the AskNews SDK
+cp .env.example .env                      # then fill in your keys (.env is gitignored)
 ```
 
 ### API Configuration
@@ -197,6 +200,58 @@ Default models per backend (override with `RACE_MODEL` / `FACT_MODEL` env vars):
 | openai     | `gpt-5.5`        | `gpt-5.4-mini`        |
 
 
+## 🔍 Generate outputs with AskNews DeepNews (this fork)
+
+DeepResearch Bench is **bring-your-own-output** — it scores reports, it does not call your agent. This fork adds [`run_deepnews.py`](run_deepnews.py), a runner that executes the **AskNews DeepNews** agent over all 100 benchmark queries and writes the exact JSONL the benchmark expects (clean report body + inline citations, with the agent's reasoning/`<final_answer>` tags stripped). Design notes, cost estimates, and tuning guidance live in [`BENCHMARKING_DEEPNEWS.md`](BENCHMARKING_DEEPNEWS.md).
+
+### 1. Keys (`.env`)
+
+After `cp .env.example .env` (see [Setup](#setup)), fill in:
+
+| Key | Used by | Notes |
+|---|---|---|
+| `ASKNEWS_API_KEY` | generation | from your AskNews account |
+| `LLM_BACKEND` | evaluation | `openai` or `openrouter` |
+| `OPENAI_API_KEY` *or* `OPENROUTER_API_KEY` | evaluation | judge access (gpt-5.5 + gpt-5.4-mini) |
+| `JINA_API_KEY` | evaluation (FACT) | web scraping |
+
+### 2. Generate the reports
+
+`run_deepnews.py` auto-loads `.env`. Start with a cheap 2-task smoke test, then run the full set:
+
+```bash
+python run_deepnews.py --ids 1,51        # 1 zh + 1 en — sanity check the output
+python run_deepnews.py                    # all 100 (resumable: re-run to retry any failures)
+```
+
+Output is written to `data/test_data/raw_data/deepnews-<engine>-<model>-d<max_depth>.jsonl`. Common flags (run `python run_deepnews.py --help` for the full list):
+
+| Flag | Purpose |
+|---|---|
+| `--ids 1,5,42` | Run specific task ids |
+| `--limit N` / `--only-en` / `--only-zh` | Scope the task set |
+| `--model` / `--engine` / `--max-depth` | DeepNews config (higher depth = better quality, more cost/time) |
+| `--workers N` | Concurrent agent calls |
+| `--model-tag` | Override the output filename stem |
+
+### 3. Score the reports
+
+`TARGET_MODELS` in `run_benchmark.sh` is already set to the default tag (`deepnews-v1.5-claude-sonnet-4-6-d6`). Unlike the runner, `run_benchmark.sh` does **not** auto-load `.env`, so export the keys into your shell first:
+
+```bash
+set -a; source .env; set +a
+bash run_benchmark.sh
+```
+
+Results land in:
+- RACE: `results/race/<tag>/race_result.txt`
+- FACT: `results/fact/<tag>/fact_result.txt`
+
+> **Tip:** for a quick end-to-end check before the full run, uncomment `LIMIT="--limit 2"` in `run_benchmark.sh` (or `export LIMIT="--limit 2"`) to score just 2 tasks.
+
+> If you changed `--model`/`--engine`/`--max-depth` during generation, update `TARGET_MODELS` to match the new filename stem.
+
+
 ## Project Structure
 
 ```
@@ -211,6 +266,9 @@ deep_research_bench/
 ├── prompt/                 # Prompt templates
 ├── utils/                  # Utility functions
 ├── deepresearch_bench_race.py  # RACE evaluation script
+├── run_deepnews.py         # ← AskNews DeepNews runner (this fork) — generates raw_data
+├── BENCHMARKING_DEEPNEWS.md    # How the runner + benchmark fit together (design + costs)
+├── .env.example            # ← Copy to .env and fill in your keys
 ├── run_benchmark.sh        # ← Add your model names here, then run
 └── requirements.txt        # Dependencies
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ tqdm>=4.65.0
 pandas>=2.0.0
 numpy>=1.24.0
 requests>=2.28.0
+# DeepNews generation runner (run_deepnews.py). PyPI package is "asknews"; import is "asknews_sdk".
+asknews>=0.13.53

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Target model name list
-TARGET_MODELS=("claude-3-7-sonnet-latest")
+# Target model name list (the <tag> run_deepnews.py wrote to data/test_data/raw_data/<tag>.jsonl)
+TARGET_MODELS=("deepnews-v1.5-claude-sonnet-4-6-d6")
 
 # Common parameters for both RACE and Citation evaluations
 RAW_DATA_DIR="data/test_data/raw_data"

--- a/run_deepnews.py
+++ b/run_deepnews.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+run_deepnews.py — Generate DeepResearch Bench outputs with the AskNews DeepNews agent.
+
+Reads the benchmark queries, runs each through `sdk.chat.get_deep_news`, extracts the
+final report (stripping agent reasoning / <final_answer> tags), and writes the
+JSONL format DeepResearch Bench expects:
+
+    {"id": <int>, "prompt": "<original query>", "article": "<report with citations>"}
+
+Output goes to  data/test_data/raw_data/<model_tag>.jsonl  (same dir DRB scores from).
+
+Resumable: re-running skips ids already present in the output file (use --force to redo).
+
+Examples
+--------
+  # quick 2-task smoke test (1 en + 1 zh), cheap
+  python run_deepnews.py --ids 1,51
+
+  # 10 English tasks only
+  python run_deepnews.py --limit 10 --only-en
+
+  # full run, opus, deeper research, 5 concurrent
+  python run_deepnews.py --model claude-opus-4-6 --max-depth 8 --workers 5
+
+Then set  TARGET_MODELS=("<tag>")  in run_benchmark.sh and `bash run_benchmark.sh`.
+
+Env
+---
+  ASKNEWS_API_KEY   AskNews API key (required). Read from the environment or a
+                    .env file at the repo root (see .env.example).
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from asknews_sdk import AskNewsSDK
+
+# --- paths (resolved relative to this file so cwd doesn't matter) ---
+ROOT = Path(__file__).resolve().parent
+QUERY_FILE = ROOT / "data" / "prompt_data" / "query.jsonl"
+RAW_DATA_DIR = ROOT / "data" / "test_data" / "raw_data"
+ENV_FILE = ROOT / ".env"
+
+
+def load_dotenv(path: Path):
+    """Minimal .env loader (no external dep): KEY=VALUE lines, '#' comments,
+    does not override variables already set in the real environment."""
+    if not path.exists():
+        return
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key, val = key.strip(), val.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = val
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Run DeepNews over DeepResearch Bench queries.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    # task selection
+    p.add_argument("-n", "--limit", type=int, default=None,
+                   help="Number of tasks to run (after language filter). Default: all 100.")
+    p.add_argument("--ids", type=str, default=None,
+                   help="Comma-separated task ids to run (overrides --limit / language filters).")
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--only-en", action="store_true", help="Only English tasks.")
+    g.add_argument("--only-zh", action="store_true", help="Only Chinese tasks.")
+    # DeepNews config
+    p.add_argument("--model", default="claude-sonnet-4-6", help="DeepNews model under test.")
+    p.add_argument("--engine", default="v1.5", choices=["v1", "v1.5", "v2.0"])
+    p.add_argument("--search-depth", type=int, default=2, help="Minimum research levels.")
+    p.add_argument("--max-depth", type=int, default=6, help="Maximum research depth.")
+    p.add_argument("--max-parallel-tool-calls", type=int, default=4)
+    p.add_argument("--sources", default="asknews,google,wiki,x",
+                   help="Comma-separated source list.")
+    p.add_argument("--max-tokens", type=int, default=32000,
+                   help="Output token cap (SDK default 9999 truncates deep reports).")
+    # run control
+    p.add_argument("--workers", type=int, default=4, help="Concurrent DeepNews calls.")
+    p.add_argument("--retries", type=int, default=3, help="Retries per task on failure.")
+    p.add_argument("--model-tag", default=None,
+                   help="Output filename stem. Default: deepnews-<engine>-<model>-d<max_depth>.")
+    p.add_argument("--force", action="store_true", help="Re-run tasks even if already in output.")
+    p.add_argument("--min-chars", type=int, default=500,
+                   help="Reject articles shorter than this (treated as failure).")
+    return p.parse_args()
+
+
+def load_queries():
+    if not QUERY_FILE.exists():
+        sys.exit(f"Query file not found: {QUERY_FILE}")
+    return [json.loads(l) for l in QUERY_FILE.open(encoding="utf-8") if l.strip()]
+
+
+def select_tasks(tasks, args):
+    if args.ids:
+        wanted = {int(x) for x in args.ids.split(",") if x.strip()}
+        return [t for t in tasks if t["id"] in wanted]
+    if args.only_en:
+        tasks = [t for t in tasks if t.get("language") == "en"]
+    elif args.only_zh:
+        tasks = [t for t in tasks if t.get("language") == "zh"]
+    tasks = sorted(tasks, key=lambda t: t["id"])
+    if args.limit is not None:
+        tasks = tasks[: args.limit]
+    return tasks
+
+
+def extract_report(full: str) -> str:
+    """Pull the report out of the raw stream: prefer the last <final_answer> block;
+    otherwise strip the agent preamble up to the first markdown heading. Citations
+    (markdown links) are left untouched."""
+    blocks = re.findall(r"<final_answer>(.*?)</final_answer>", full, re.DOTALL)
+    if blocks:
+        return blocks[-1].strip()
+    m = re.search(r"^#{1,6}\s", full, re.MULTILINE)
+    return (full[m.start():] if m else full).strip()
+
+
+def done_ids(out_path: Path) -> set:
+    if not out_path.exists():
+        return set()
+    ids = set()
+    for line in out_path.open(encoding="utf-8"):
+        line = line.strip()
+        if line:
+            try:
+                ids.add(json.loads(line)["id"])
+            except (json.JSONDecodeError, KeyError):
+                pass
+    return ids
+
+
+def make_runner(sdk, args):
+    sources = [s.strip() for s in args.sources.split(",") if s.strip()]
+
+    def run_one(task):
+        last_err = None
+        for attempt in range(1, args.retries + 1):
+            try:
+                parts = []
+                resp = sdk.chat.get_deep_news(
+                    messages=[{"role": "user", "content": task["prompt"]}],
+                    stream=True,
+                    model=args.model,
+                    engine=args.engine,
+                    search_depth=args.search_depth,
+                    max_depth=args.max_depth,
+                    max_parallel_tool_calls=args.max_parallel_tool_calls,
+                    sources=sources,
+                    inline_citations="markdown_link",
+                    append_references=True,
+                    return_sources=True,
+                    asknews_watermark=False,
+                    max_tokens=args.max_tokens,
+                )
+                for msg in resp:
+                    choices = getattr(msg, "choices", None)  # source objects have none
+                    if not choices:
+                        continue
+                    content = getattr(choices[0].delta, "content", None)
+                    if content:
+                        parts.append(content)
+                article = extract_report("".join(parts))
+                if len(article) < args.min_chars:
+                    raise RuntimeError(f"article too short ({len(article)} chars)")
+                if "http" not in article:
+                    raise RuntimeError("no citation URLs in article")
+                return {"id": task["id"], "prompt": task["prompt"], "article": article}
+            except Exception as e:  # noqa: BLE001 — log and retry transient failures
+                last_err = e
+                if attempt < args.retries:
+                    time.sleep(2 ** attempt)
+        raise RuntimeError(f"id={task['id']} failed after {args.retries} tries: {last_err}")
+
+    return run_one
+
+
+def main():
+    args = parse_args()
+    load_dotenv(ENV_FILE)
+
+    tag = args.model_tag or f"deepnews-{args.engine}-{args.model}-d{args.max_depth}"
+    out_path = RAW_DATA_DIR / f"{tag}.jsonl"
+    RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    tasks = select_tasks(load_queries(), args)
+    already = set() if args.force else done_ids(out_path)
+    pending = [t for t in tasks if t["id"] not in already]
+
+    print(f"Output : {out_path}")
+    print(f"Model  : {args.model}  engine={args.engine}  depth={args.search_depth}..{args.max_depth}")
+    print(f"Tasks  : {len(tasks)} selected, {len(already & {t['id'] for t in tasks})} already done, "
+          f"{len(pending)} to run  (workers={args.workers})")
+    if not pending:
+        print("Nothing to do.")
+        return
+
+    api_key = os.environ.get("ASKNEWS_API_KEY")
+    if not api_key:
+        sys.exit("ASKNEWS_API_KEY not set. Export it or add it to a .env file at the repo "
+                 "root (see .env.example).")
+    sdk = AskNewsSDK(api_key=api_key, scopes=["chat", "news", "stories"])
+    run_one = make_runner(sdk, args)
+
+    lock = threading.Lock()
+    write_f = out_path.open("a", encoding="utf-8")
+    ok = fail = 0
+    try:
+        with ThreadPoolExecutor(max_workers=args.workers) as ex:
+            futs = {ex.submit(run_one, t): t for t in pending}
+            for fut in as_completed(futs):
+                tid = futs[fut]["id"]
+                try:
+                    rec = fut.result()
+                    with lock:
+                        write_f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+                        write_f.flush()
+                    ok += 1
+                    print(f"  ✓ {tid:>3}  ({len(rec['article'])} chars)  [{ok+fail}/{len(pending)}]")
+                except Exception as e:  # noqa: BLE001
+                    fail += 1
+                    print(f"  ✗ {tid:>3}  {e}  [{ok+fail}/{len(pending)}]")
+    finally:
+        write_f.close()
+
+    print(f"\nDone. {ok} ok, {fail} failed. Total in file: {len(done_ids(out_path))}/100")
+    if fail:
+        print("Re-run the same command to retry failed tasks (they were not written).")
+    print(f"\nNext: set  TARGET_MODELS=(\"{tag}\")  in run_benchmark.sh, then `bash run_benchmark.sh`.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Add an AskNews DeepNews runner for DeepResearch Bench

## Summary

DeepResearch Bench is **bring-your-own-output** — it scores reports but doesn't call the agent that produced them. This PR adds the missing piece for **DeepNews**: a runner that executes the DeepNews agent over all 100 benchmark queries and writes the exact JSONL the RACE + FACT pipelines expect. No evaluation code is changed — the addition is purely the generation side plus docs.

With this, scoring DeepNews is a two-command flow:

```bash
python run_deepnews.py            # generate reports for the 100 queries
bash run_benchmark.sh             # score them (RACE + FACT)
```

## What's added

| File | Purpose |
|------|---------|
| `run_deepnews.py` | The runner — calls `sdk.chat.get_deep_news` per query, extracts the clean report body, writes DRB-shaped JSONL. Resumable, concurrent, with retries. |
| `BENCHMARKING_DEEPNEWS.md` | Design notes: how the runner and benchmark fit together, the citation/extraction details, cost & time estimates, and the execution plan. |
| `.env.example` | Template for the keys (generation + evaluation). `.env` is gitignored. |
| `requirements.txt` | Adds the `asknews` SDK dependency. |
| `run_benchmark.sh` | `TARGET_MODELS` preset to the default DeepNews tag. |
| `README.md` | New "Generate outputs with AskNews DeepNews" section + updated Setup/Prerequisites/Project Structure. |

## How it works

1. **Generate** — `run_deepnews.py` reads `data/prompt_data/query.jsonl`, runs each prompt through DeepNews (streaming), and writes one line per task to `data/test_data/raw_data/<tag>.jsonl` in the required shape:
   ```json
   {"id": 1, "prompt": "<original query>", "article": "<report with inline citations>"}
   ```
2. **Score** — `run_benchmark.sh` runs the unchanged RACE (report quality) and FACT (citation accuracy) pipelines over that file.

### Output tag

The filename stem encodes the run config for reproducibility: `deepnews-<engine>-<model>-d<max_depth>` (e.g. `deepnews-v1.5-claude-sonnet-4-6-d6`). `--model-tag` overrides it.

## Design notes

- **Report extraction.** A raw DeepNews stream contains agent reasoning and the report wrapped in `<final_answer>…</final_answer>` tags. The runner emits **only** the final report body (last `<final_answer>` block, or first markdown heading onward as a fallback), so RACE doesn't penalize meta-commentary and FACT doesn't waste calls on narration.
- **Citations need no special handling.** DeepNews emits inline citations as `[label](url)`, which FACT's extractor parses natively — no reference reconciliation required.
- **Secrets via env only.** Keys are read from the environment or a gitignored `.env` (the runner auto-loads it); no key is committed anywhere.
- **Package naming.** The DeepNews SDK is the `asknews` package on PyPI but imports as `asknews_sdk` — `requirements.txt` reflects this so a fresh clone installs cleanly.
- **Robustness.** Bounded concurrency (`--workers`), exponential-backoff retries (`--retries`), resumability (re-running skips completed ids), and guards that reject truncated / citation-less articles so a bad run fails loudly instead of silently tanking the score.

## Usage

```bash
python -m venv env && source env/bin/activate
pip install -r requirements.txt
cp .env.example .env          # fill in ASKNEWS / OPENAI (or OPENROUTER) / JINA keys

# generate
python run_deepnews.py --ids 1,51    # cheap 2-task smoke test (1 zh + 1 en)
python run_deepnews.py                # all 100 (resumable)

# score
set -a; source .env; set +a          # run_benchmark.sh does not auto-load .env
bash run_benchmark.sh
```

Common flags: `--limit N`, `--only-en` / `--only-zh`, `--model`, `--engine`, `--max-depth`, `--workers`, `--model-tag` (`--help` for all).

## Verification

Validated end-to-end on a 2-task subset (1 EN + 1 ZH) with the OpenAI-backed GPT-5.5 / gpt-5.4-mini evaluator:

- ✅ Generation produces clean report bodies (no preamble / `<final_answer>` leakage) with inline `[label](url)` citations.
- ✅ RACE pipeline runs and scores the reports.
- ✅ FACT pipeline runs (extract → dedup → scrape → validate) and reports citation accuracy.
- ✅ Fresh-clone install works from `requirements.txt`.

The full 100-task scored run is the natural next step; this PR establishes the reproducible harness to do it.

## Notes for reviewers

- **No evaluation code is modified** — the diff is additive (runner + docs + config). The RACE/FACT pipelines are untouched.